### PR TITLE
Luw2007 修正无法运行的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@
 #
 
 # Pull base image.
-FROM ubuntu:14.04
+#FROM ubuntu:14.04
+FROM docker.cn/docker/ubuntu:latest # use docker.cn
 MAINTAINER Nyk Ma <moe@nayuki.info>
 
 # Install.
 RUN \
+  sed -i 's%/archive.ubuntu.com%/cn.archive.ubuntu.com%g' /etc/apt/sources.list && \ # use cn source
   sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
   apt-get update && \
   apt-get -y upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,5 @@ RUN rm leanote.tar.gz && \
 # Run leanote.
 CMD ["/bin/bash","/root/start.sh"]
 # CMD ["bash"]
-EXPOSE 80
+EXPOSE 9000
 VOLUME ["/root/notedata","/var/log","/root/leanote/conf"]

--- a/start.sh
+++ b/start.sh
@@ -8,5 +8,4 @@ else
   mongod --dbpath /root/notedata --fork --logpath=/var/log/mongodb.log --auth
 fi
 
-chmod a+x /root/leanote/bin/leanote-linux
-/root/leanote/bin/leanote-linux -importPath github.com/leanote/leanote
+cd /root/leanote/bin; bash run.sh


### PR DESCRIPTION
1. 解决国内访问as过慢, 导致下载docker images超时, 因此改成国内docker.cn 源
2. 启动使用run.sh 替换掉leanote-linux 
3. 默认端口 9000 
